### PR TITLE
Replace shader of the imported font in Linux

### DIFF
--- a/FontLoader/FontUtil.cs
+++ b/FontLoader/FontUtil.cs
@@ -25,6 +25,10 @@ namespace FontLoader.Utils
                 
                 font = ab.LoadAllAssets<TMP_FontAsset>()[0];
                 font.fontInfo.Scale = config.Scale;
+                
+                if (Application.platform == RuntimePlatform.LinuxPlayer) {
+                    font.material.shader = Resources.Load<TMP_FontAsset>("RobotoCondensed-Regular").material.shader;
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
實測了一下，Linux 的部分雖然可以沿用 macOS 生產的檔案，還是一定要把 shader 換掉才行。就算是在 Linux 底下打包的檔案也要，雖然還不清楚為什麼。